### PR TITLE
Message should not be mashed with the initial event data

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -27,11 +27,11 @@ class Workflow
 
   def self.mash(config, event)
 
-    fields_not_to_mash = []
+    fields_not_to_mash = ['message']
 
     config
       .select { |_, y| y.is_a? String }
-      .reject { |x, _| fields_not_to_mash.include? x }
+      .reject { |x, _| fields_not_to_mash.include? x.to_s }
       .each do |key, value|
         config[key] = mash_single_value(value, event)
       end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -26,8 +26,12 @@ class Workflow
   end
 
   def self.mash(config, event)
+
+    fields_not_to_mash = []
+
     config
       .select { |_, y| y.is_a? String }
+      .reject { |x, _| fields_not_to_mash.include? x }
       .each do |key, value|
         config[key] = mash_single_value(value, event)
       end


### PR DESCRIPTION
By default, event handler configs are mashed against the event data.

So config like ```foo = {{bar}}```

will be converted to ```foo= abc``` if the event data has ```bar = abc```.

But the "message" is meant to be processed not when the event handler is set up, but when more events are fired from the event handler.  So we want to hold off on running liquid templating on the "message" until later.